### PR TITLE
Enhance SSR implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /public/storage
 /storage/*.key
 /storage/pail
+/bootstrap/ssr
 /vendor
 Homestead.json
 Homestead.yaml

--- a/bootstrap/ssr/.gitignore
+++ b/bootstrap/ssr/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/resources/js/frontend.tsx
+++ b/resources/js/frontend.tsx
@@ -1,6 +1,6 @@
 import { createInertiaApp } from "@inertiajs/react";
 import { type ComponentProps } from "react";
-import { hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import Layout from "./layouts/layout";
 
 createInertiaApp({
@@ -25,6 +25,10 @@ createInertiaApp({
     return page;
   },
   setup({ el, App, props }) {
-    hydrateRoot(el, <App {...props} />);
+    if (import.meta.env.DEV) {
+      createRoot(el).render(<App {...props} />);
+    } else {
+      hydrateRoot(el, <App {...props} />);
+    }
   },
 });

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -1,13 +1,17 @@
 import { createInertiaApp } from "@inertiajs/react";
 import createServer from "@inertiajs/react/server";
 import { type ComponentProps } from "react";
-import ReactDOMServer from "react-dom/server";
+import { renderToReadableStream, renderToString } from "react-dom/server";
 import Layout from "./layouts/layout";
 
 createServer((page) =>
   createInertiaApp({
     page,
-    render: ReactDOMServer.renderToString,
+    render: (async (element: React.ReactNode) => {
+      const stream = await renderToReadableStream(element);
+      await stream.allReady;
+      return new Response(stream).text();
+    }) as unknown as typeof renderToString,
     resolve: (name) => {
       const appPages = import.meta.glob("@/pages/**/*.tsx", {
         eager: true,


### PR DESCRIPTION
- Improve Suspense handling by using renderToReadableStream instead of renderToString. While renderToString worked previously, it rendered a warning on the first render after starting the ssr server, or would always throw a hydration mismatch error in the console. Now it should work without workarounds in the React code.
- The dev server does not render server-side, therefore the root should be created client-side and not hydrated. This fix prevents the hydration mismatch error to be always thrown in dev mode.
- Remove the gitignore from bootstrap/app and adding an according line to the root .gitignore file, because the .gitignore file would be removed when building the ssr bundle.